### PR TITLE
codeforpoznan.pl_v2 static frontend infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform/

--- a/codeforpoznan_pl_v2.tf
+++ b/codeforpoznan_pl_v2.tf
@@ -1,0 +1,76 @@
+resource "aws_s3_bucket_object" "codeforpoznan_pl_v2" {
+  bucket = aws_s3_bucket.codeforpoznan_public.id
+  key    = "codeforpoznan.pl_v2/"
+}
+
+resource "aws_iam_policy" "codeforpoznan_pl_v2" {
+  name   = "codeforpoznan.pl_v2"
+
+  policy = <<POLICY
+{
+  "Version":"2012-10-17",
+  "Statement":[{
+    "Sid":"PublicListBucket",
+    "Effect":"Allow",
+    "Action":["s3:PutObject"],
+    "Resource":["arn:aws:s3:::codeforpoznan-public/codeforpoznan.pl_v2/*"]
+  }]
+}
+  POLICY
+}
+
+resource "aws_iam_user" "codeforpoznan_pl_v2" {
+  name = "codeforpoznan_pl_v2"
+}
+
+resource "aws_iam_access_key" "codeforpoznan_pl_v2" {
+  user = aws_iam_user.codeforpoznan_pl_v2.name
+}
+
+resource "aws_iam_policy_attachment" "codeforpoznan_pl_v2" {
+  name       = "codeforpoznan_pl_v2"
+  policy_arn = aws_iam_policy.codeforpoznan_pl_v2.arn
+  users      = [aws_iam_user.codeforpoznan_pl_v2.name]
+}
+
+resource "aws_cloudfront_distribution" "codeforpoznan_pl_v2" {
+  origin {
+    domain_name = "codeforpoznan-public.s3-eu-west-1.amazonaws.com"
+    origin_path = "/codeforpoznan.pl_v2/init"
+    origin_id   = "codeforpoznan_pl_v2"
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  aliases             = ["codeforpoznan.pl"]
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "codeforpoznan_pl_v2"
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = aws_acm_certificate.codeforpoznan_pl.arn
+    ssl_support_method  = "sni-only"
+  }
+}

--- a/codeforpoznan_pl_v2.tf
+++ b/codeforpoznan_pl_v2.tf
@@ -10,13 +10,23 @@ resource "aws_iam_policy" "codeforpoznan_pl_v2" {
 {
   "Version":"2012-10-17",
   "Statement":[{
-    "Sid":"PublicListBucket",
+    "Sid":"CodeForPoznanV2S3",
     "Effect":"Allow",
-    "Action":["s3:PutObject"],
-    "Resource":["arn:aws:s3:::codeforpoznan-public/codeforpoznan.pl_v2/*"]
+    "Action":["s3:DeleteObject", "s3:PutObject"],
+    "Resource":["${aws_s3_bucket.codeforpoznan_public.arn}/${aws_s3_bucket_object.codeforpoznan_pl_v2.key}*"]
+  }, {
+    "Sid":"CodeForPoznanV2Distribution",
+    "Effect":"Allow",
+    "Action":["cloudfront:CreateInvalidation"],
+    "Resource":["${aws_cloudfront_distribution.codeforpoznan_pl_v2.arn}"]
   }]
 }
   POLICY
+
+  depends_on = [
+    aws_s3_bucket_object.codeforpoznan_pl_v2,
+    aws_cloudfront_distribution.codeforpoznan_pl_v2,
+  ]
 }
 
 resource "aws_iam_user" "codeforpoznan_pl_v2" {
@@ -36,7 +46,7 @@ resource "aws_iam_policy_attachment" "codeforpoznan_pl_v2" {
 resource "aws_cloudfront_distribution" "codeforpoznan_pl_v2" {
   origin {
     domain_name = "codeforpoznan-public.s3-eu-west-1.amazonaws.com"
-    origin_path = "/codeforpoznan.pl_v2/init"
+    origin_path = "/codeforpoznan.pl_v2"
     origin_id   = "codeforpoznan_pl_v2"
   }
 
@@ -73,4 +83,8 @@ resource "aws_cloudfront_distribution" "codeforpoznan_pl_v2" {
     acm_certificate_arn = aws_acm_certificate.codeforpoznan_pl.arn
     ssl_support_method  = "sni-only"
   }
+
+  depends_on = [
+    aws_s3_bucket_object.codeforpoznan_pl_v2,
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,100 @@
+terraform {
+  backend "s3" {
+    bucket  = "codeforpoznan-tfstate"
+    key     = "codeforpoznan.tfstate"
+    profile = "codeforpoznan"
+    region  = "eu-west-1"
+  }
+}
+
+provider "aws" {
+  region  = "eu-west-1"
+  profile = "codeforpoznan"
+}
+
+provider "aws" {
+  alias   = "north_virginia"
+  region  = "us-east-1"
+  profile = "codeforpoznan"
+}
+
+// admin users
+resource "aws_iam_user" "tomasz_magulski" {
+  name = "tomasz_magulski"
+}
+
+resource "aws_iam_access_key" "tomasz_magulski" {
+  user = aws_iam_user.tomasz_magulski.name
+}
+
+resource "aws_iam_policy_attachment" "administrator_access" {
+  name       = "AdministratorAccess"
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+  users      = [aws_iam_user.tomasz_magulski.name]
+}
+
+// shared public bucket (we will push here all static assets in separate directories)
+resource "aws_s3_bucket" "codeforpoznan_public" {
+  bucket = "codeforpoznan-public"
+
+  cors_rule {
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = ["*"]
+  }
+
+  policy = <<POLICY
+{
+  "Version":"2012-10-17",
+  "Statement":[{
+    "Sid":"PublicListBucket",
+    "Effect":"Allow",
+    "Principal": "*",
+    "Action":["s3:ListBucket"],
+    "Resource":["arn:aws:s3:::codeforpoznan-public"]
+  }, {
+    "Sid":"PublicGetObject",
+    "Effect":"Allow",
+    "Principal": "*",
+    "Action":["s3:GetObject"],
+    "Resource":["arn:aws:s3:::codeforpoznan-public/*"]
+  }]
+}
+    POLICY
+}
+
+// DNS zone for codeforpoznan.pl
+resource "aws_route53_zone" "codeforpoznan_pl" {
+  name = "codeforpoznan.pl"
+}
+
+resource "aws_route53_record" "codeforpoznan_pl" {
+  name    = "codeforpoznan.pl"
+  type    = "A"
+  zone_id = aws_route53_zone.codeforpoznan_pl.id
+
+  alias {
+    name                   = aws_cloudfront_distribution.codeforpoznan_pl_v2.domain_name
+    zone_id                = aws_cloudfront_distribution.codeforpoznan_pl_v2.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_acm_certificate" "codeforpoznan_pl" {
+  domain_name               = "codeforpoznan.pl"
+  validation_method         = "DNS"
+  provider                  = aws.north_virginia
+}
+
+resource "aws_route53_record" "codeforpoznan_pl_cert_validation" {
+  name    = aws_acm_certificate.codeforpoznan_pl.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.codeforpoznan_pl.domain_validation_options.0.resource_record_type
+  zone_id = aws_route53_zone.codeforpoznan_pl.id
+  records = [aws_acm_certificate.codeforpoznan_pl.domain_validation_options.0.resource_record_value]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "codeforpoznan_pl" {
+  certificate_arn         = aws_acm_certificate.codeforpoznan_pl.arn
+  validation_record_fqdns = [aws_route53_record.codeforpoznan_pl_cert_validation.fqdn]
+  provider                = aws.north_virginia
+}


### PR DESCRIPTION
First draft for infrastructure needed to serve static assets for `codeforpoznan.pl_v2`.

It's still lacking permissions to update Cloudformation for `codeforpoznan.pl_v2` user. Eventually, plan is to run something like that on Travis:
```
aws s3 cp ...
aws cloudfront update-distribution ...
```