### PR TITLE
Module for creating generic serverless API using API Gateway and Lambda

### DIFF
--- a/codeforpoznan_pl_v2.tf
+++ b/codeforpoznan_pl_v2.tf
@@ -15,3 +15,54 @@ module codeforpoznan_pl_v2_frontend_assets {
   route53_zone = aws_route53_zone.codeforpoznan_pl
   iam_user     = aws_iam_user.codeforpoznan_pl_v2
 }
+
+resource "aws_ses_domain_identity" "codeforpoznan_pl" {
+  domain = "codeforpoznan.pl"
+}
+
+resource "aws_route53_record" "codeforpoznan_pl_ses_verification_record" {
+  zone_id = aws_route53_zone.codeforpoznan_pl.id
+  name    = "_amazonses.${aws_ses_domain_identity.codeforpoznan_pl.domain}"
+  type    = "TXT"
+  ttl     = "600"
+  records = [aws_ses_domain_identity.codeforpoznan_pl.verification_token]
+
+  depends_on = [
+    aws_ses_domain_identity.codeforpoznan_pl,
+  ]
+}
+
+resource "aws_ses_domain_identity_verification" "codeforpoznan_pl" {
+  domain = aws_ses_domain_identity.codeforpoznan_pl.domain
+
+  depends_on = [
+    aws_route53_record.codeforpoznan_pl_ses_verification_record,
+  ]
+}
+
+resource "aws_iam_policy" "codeforpoznan_pl_ses_policy" {
+  name = "codeforpoznan_pl_v2_lambda_execution_policy"
+
+  policy = <<POLICY
+{
+  "Version":"2012-10-17",
+  "Statement":[{
+    "Sid":"CodeforpoznanPlV2SES",
+    "Effect":"Allow",
+    "Action":["ses:SendEmail", "ses:SendRawEmail"],
+    "Resource":["${aws_ses_domain_identity.codeforpoznan_pl.arn}"]
+  }]
+}
+  POLICY
+}
+
+module codeforpoznan_pl_v2_serverless_api {
+  source              = "./serverless_api"
+
+  name                = "codeforpoznan.pl_v2"
+  runtime             = "nodejs10.x"
+  handler             = "contact_me.handler"
+  s3_bucket           = aws_s3_bucket.codeforpoznan_lambdas
+  iam_user            = aws_iam_user.codeforpoznan_pl_v2
+  additional_policies = [aws_iam_policy.codeforpoznan_pl_ses_policy]
+}

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,11 @@ resource "aws_s3_bucket" "codeforpoznan_public" {
     POLICY
 }
 
+resource "aws_s3_bucket" "codeforpoznan_lambdas" {
+  bucket = "codeforpoznan-lambdas"
+  acl    = "private"
+}
+
 // DNS zone for codeforpoznan.pl
 resource "aws_route53_zone" "codeforpoznan_pl" {
   name = "codeforpoznan.pl"

--- a/serverless_api/main.tf
+++ b/serverless_api/main.tf
@@ -1,0 +1,157 @@
+variable name {
+  type = string
+}
+variable runtime {
+  type = string
+}
+variable handler {
+  type = string
+}
+
+variable s3_bucket { }
+variable iam_user { }
+variable additional_policies {
+  type = list
+}
+
+resource "aws_iam_role" "role" {
+  name               = "${var.name}_serverless_api"
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": [
+            "lambda.amazonaws.com"
+        ]
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+  POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "role_policy_attachment" {
+  role       = aws_iam_role.role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "additional_role_policy_attachment" {
+  role       = aws_iam_role.role.name
+  policy_arn = var.additional_policies[count.index].arn
+
+  count      = length(var.additional_policies)
+}
+
+resource "aws_s3_bucket_object" "bucket_object" {
+  bucket         = var.s3_bucket.id
+  key            = "${var.name}.zip"
+  // small zip with emtpy index.js
+  content_base64 = "UEsDBAoAAAAAACykUFAAAAAAAAAAAAAAAAAIABwAaW5kZXguanNVVAkAAwSZSV4EmUledXgLAAEE6AMAAAToAwAAUEsBAh4DCgAAAAAALKRQUAAAAAAAAAAAAAAAAAgAGAAAAAAAAAAAAKSBAAAAAGluZGV4LmpzVVQFAAMEmUledXgLAAEE6AMAAAToAwAAUEsFBgAAAAABAAEATgAAAEIAAAAAAA=="
+
+  depends_on = [
+    var.s3_bucket,
+  ]
+}
+
+resource "aws_lambda_function" "function" {
+  function_name = replace(var.name, ".", "_")
+
+  s3_bucket = var.s3_bucket.id
+  s3_key = "${var.name}.zip"
+
+  role = aws_iam_role.role.arn
+  handler = var.handler
+  runtime = var.runtime
+
+  depends_on = [
+    aws_iam_role.role,
+    aws_s3_bucket_object.bucket_object,
+  ]
+}
+
+resource "aws_api_gateway_rest_api" "rest_api" {
+  name = var.name
+}
+
+resource "aws_api_gateway_method" "method" {
+  rest_api_id      = aws_api_gateway_rest_api.rest_api.id
+  resource_id      = aws_api_gateway_rest_api.rest_api.root_resource_id
+  http_method      = "ANY"
+  authorization    = "NONE"
+  api_key_required = "false"
+
+  depends_on = [
+    aws_api_gateway_rest_api.rest_api,
+  ]
+}
+
+resource "aws_api_gateway_integration" "integration" {
+  rest_api_id             = aws_api_gateway_rest_api.rest_api.id
+  resource_id             = aws_api_gateway_rest_api.rest_api.root_resource_id
+  http_method             = aws_api_gateway_method.method.http_method
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.function.invoke_arn
+  integration_http_method = "ANY"
+
+  depends_on = [
+    aws_api_gateway_method.method,
+    aws_lambda_function.function,
+  ]
+}
+
+resource "aws_api_gateway_deployment" "deployment" {
+  rest_api_id = aws_api_gateway_rest_api.rest_api.id
+  stage_name = "devel"
+
+  depends_on = [
+      aws_api_gateway_integration.integration,
+  ]
+}
+
+resource "aws_lambda_permission" "permission" {
+  function_name = aws_lambda_function.function.function_name
+  statement_id  = "${replace(title(replace(var.name, "/[\\._]/", " ")), " ", "")}Invoke"
+  action        = "lambda:InvokeFunction"
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${replace(aws_api_gateway_deployment.deployment.execution_arn, "devel", "")}*/*"
+}
+
+resource "aws_iam_policy" "policy" {
+  name   = "${var.name}_serverless_api"
+
+  policy = <<POLICY
+{
+  "Version":"2012-10-17",
+  "Statement":[{
+    "Sid":"${replace(title(replace(var.name, "/[\\._]/", " ")), " ", "")}S3",
+    "Effect":"Allow",
+    "Action":["s3:GetObject", "s3:PutObject"],
+    "Resource":["${var.s3_bucket.arn}/${aws_s3_bucket_object.bucket_object.key}"]
+  }, {
+    "Sid":"${replace(title(replace(var.name, "/[\\._]/", " ")), " ", "")}Lambda",
+    "Effect":"Allow",
+    "Action":["lambda:UpdateFunctionCode"],
+    "Resource":["${aws_lambda_function.function.arn}"]
+  }]
+}
+  POLICY
+
+  depends_on = [
+    aws_s3_bucket_object.bucket_object,
+  ]
+}
+
+resource "aws_iam_user_policy_attachment" "user_policy_attachment" {
+  user       = var.iam_user.name
+  policy_arn = aws_iam_policy.policy.arn
+
+  depends_on = [
+    aws_iam_policy.policy,
+    var.iam_user,
+  ]
+}


### PR DESCRIPTION
There are still a few things missing (but don't want to do them in this pull request):
 * CloudFormation distribution should be moved out from `frontend_assets` as we're going to hide behind it both frontend assets and API gateway (see for reference: https://i.stack.imgur.com/zhmhv.png)
 * ACM domain verification as a flow will be moved to separate module
 * SES domain verification as a flow will be moved to separate module 