### PR TITLE
Add basic description of alinka-website repo

### DIFF
--- a/alinka_website.tf
+++ b/alinka_website.tf
@@ -1,0 +1,21 @@
+resource "aws_iam_user" "alinka_website" {
+  name = "alinka_website"
+}
+
+resource "aws_iam_access_key" "alinka_website" {
+  user = aws_iam_user.alinka_website.name
+}
+
+resource "aws_route53_zone" "alinka_website" {
+    name = "alinka.io"
+}
+
+module alinka_website_frontend_assets {
+  source       = "./frontend_assets"
+
+  name         = "alinka_website"
+  domain       = "alinka.io"
+  s3_bucket    = aws_s3_bucket.codeforpoznan_public
+  route53_zone = aws_route53_zone.alinka_website
+  iam_user     = aws_iam_user.alinka_website
+}

--- a/alinka_website.tf
+++ b/alinka_website.tf
@@ -14,7 +14,7 @@ module alinka_website_frontend_assets {
   source       = "./frontend_assets"
 
   name         = "alinka_website"
-  domain       = "alinka.io"
+  domain       = "dev.alinka.io"
   s3_bucket    = aws_s3_bucket.codeforpoznan_public
   route53_zone = aws_route53_zone.alinka_website
   iam_user     = aws_iam_user.alinka_website


### PR DESCRIPTION
I've moved `route53_zone` out of the `main.tf` because it seemed to me like the domain name is more specific to that particular file rather than main file.