### PR TITLE
Fixing user policy attachment

### DIFF
--- a/admin/main.tf
+++ b/admin/main.tf
@@ -10,8 +10,7 @@ resource "aws_iam_access_key" "access_key" {
   user = aws_iam_user.user.name
 }
 
-resource "aws_iam_policy_attachment" "policy_attachment" {
-  name       = "AdministratorAccess"
+resource "aws_iam_user_policy_attachment" "policy_attachment" {
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-  users      = [aws_iam_user.user.name]
+  user       = aws_iam_user.user.name
 }


### PR DESCRIPTION
> WARNING: The aws_iam_policy_attachment resource creates exclusive attachments of IAM policies. Across the entire AWS account, all of the users/roles/groups to which a single policy is attached must be declared by a single aws_iam_policy_attachment resource. This means that even any users/roles/groups that have the attached policy via any other mechanism (including other Terraform resources) will have that attached policy revoked by this resource. Consider aws_iam_role_policy_attachment, aws_iam_user_policy_attachment, or aws_iam_group_policy_attachment instead. These resources do not enforce exclusive attachment of an IAM policy.

see: https://www.terraform.io/docs/providers/aws/r/iam_policy_attachment.html