### PR TITLE
Terraform Empatia project and bankempatii.pl domain

### DIFF
--- a/empatia.tf
+++ b/empatia.tf
@@ -7,7 +7,103 @@ resource "aws_iam_access_key" "empatia" {
 }
 
 resource "aws_route53_zone" "empatia" {
-    name = "bankempatii.pl"
+  name = "bankempatii.pl"
+}
+
+resource "aws_route53_record" "a_empatia" {
+  zone_id = aws_route53_zone.empatia.zone_id
+  name    = aws_route53_zone.empatia.name
+  type    = "A"
+  alias {
+    evaluate_target_health = false
+    name                   = "d6cxmr8432pje.cloudfront.net"
+    zone_id                = "Z2FDTNDATAQYW2"
+  }
+}
+
+resource "aws_route53_record" "a_www_empatia" {
+  zone_id = aws_route53_zone.empatia.zone_id
+  name    = "www.${aws_route53_zone.empatia.name}"
+  type    = "A"
+  ttl     = "300"
+  records = [
+    "176.31.162.42",
+  ]
+}
+
+resource "aws_route53_record" "mx_empatia" {
+  zone_id = aws_route53_zone.empatia.zone_id
+  name    = aws_route53_zone.empatia.name
+  type    = "MX"
+  ttl     = "300"
+  records = [
+    "1 redirect.ovh.net",
+  ]
+}
+
+resource "aws_route53_record" "mx_www_empatia" {
+  zone_id = aws_route53_zone.empatia.zone_id
+  name    = "www.${aws_route53_zone.empatia.name}"
+  type    = "MX"
+  ttl     = "300"
+  records = [
+    "1 redirect.ovh.net",
+  ]
+}
+
+resource "aws_route53_record" "ns_empatia" {
+  zone_id = aws_route53_zone.empatia.zone_id
+  name    = aws_route53_zone.empatia.name
+  type    = "NS"
+  ttl     = "172800"
+  records = [
+    "ns-214.awsdns-26.com",
+    "ns-1083.awsdns-07.org",
+    "ns-1596.awsdns-07.co.uk",
+    "ns-854.awsdns-42.net",
+  ]
+}
+
+resource "aws_route53_record" "soa_empatia" {
+  zone_id = aws_route53_zone.empatia.zone_id
+  name    = aws_route53_zone.empatia.name
+  type    = "SOA"
+  ttl     = "900"
+  records = [
+    "ns-1596.awsdns-07.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400",
+  ]
+}
+
+resource "aws_route53_record" "cname_empatia" {
+  zone_id = aws_route53_zone.empatia.zone_id
+  name    = "_ac65bc401f2ef9831b5de3354b6cc298.${aws_route53_zone.empatia.name}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = [
+    "_99b56888aa18364008e7b7ca51d0325c.ltfvzjuylp.acm-validations.aws",
+  ]
+}
+
+resource "aws_route53_record" "txt_empatia" {
+  zone_id = aws_route53_zone.empatia.zone_id
+  name    = aws_route53_zone.empatia.name
+  type    = "TXT"
+  ttl     = "300"
+  records = [
+    "\"1|www.${aws_route53_zone.empatia.name}\"",
+    "\"v=spf1 include:mx.ovh.com ~all\"",
+  ]
+}
+
+resource "aws_route53_record" "txt_www_empatia" {
+  zone_id = aws_route53_zone.empatia.zone_id
+  name    = "www.${aws_route53_zone.empatia.name}"
+  type    = "TXT"
+  ttl     = "300"
+  records = [
+    "\"3|welcome\"",
+    "\"l|pl\"",
+  ]
 }
 
 module empatia_ssl_certificate {

--- a/empatia.tf
+++ b/empatia.tf
@@ -1,0 +1,45 @@
+resource "aws_iam_user" "empatia" {
+  name = "empatia"
+}
+
+resource "aws_iam_access_key" "empatia" {
+  user = aws_iam_user.empatia.name
+}
+
+resource "aws_route53_zone" "empatia" {
+    name = "bankempatii.pl"
+}
+
+module empatia_ssl_certificate {
+  source       = "./ssl_certificate"
+
+  domain       = aws_route53_zone.empatia.name
+  route53_zone = aws_route53_zone.empatia
+}
+
+module empatia_frontend_assets {
+  source    = "./frontend_assets"
+
+  name      = "empatia"
+  s3_bucket = aws_s3_bucket.codeforpoznan_public
+  iam_user  = aws_iam_user.empatia
+}
+
+module empatia_cloudfront_distribution {
+  source          = "./cloudfront_distribution"
+
+  name            = "empatia"
+  domain          = aws_route53_zone.empatia.name
+  s3_bucket       = aws_s3_bucket.codeforpoznan_public
+  route53_zone    = aws_route53_zone.empatia
+  iam_user        = aws_iam_user.empatia
+  acm_certificate = module.empatia_ssl_certificate.certificate
+
+  origins         = {
+    static_assets = {
+      default     = true
+      domain_name = aws_s3_bucket.codeforpoznan_public.bucket_domain_name
+      origin_path = "/empatia"
+    }
+  }
+}

--- a/empatia.tf
+++ b/empatia.tf
@@ -10,57 +10,16 @@ resource "aws_route53_zone" "empatia" {
   name = "bankempatii.pl"
 }
 
-resource "aws_route53_record" "a_empatia" {
-  zone_id = aws_route53_zone.empatia.zone_id
-  name    = aws_route53_zone.empatia.name
-  type    = "A"
-  alias {
-    evaluate_target_health = false
-    name                   = "d6cxmr8432pje.cloudfront.net"
-    zone_id                = "Z2FDTNDATAQYW2"
-  }
-}
-
-resource "aws_route53_record" "a_www_empatia" {
-  zone_id = aws_route53_zone.empatia.zone_id
-  name    = "www.${aws_route53_zone.empatia.name}"
-  type    = "A"
-  ttl     = "300"
-  records = [
-    "176.31.162.42",
-  ]
-}
-
-resource "aws_route53_record" "mx_empatia" {
-  zone_id = aws_route53_zone.empatia.zone_id
-  name    = aws_route53_zone.empatia.name
-  type    = "MX"
-  ttl     = "300"
-  records = [
-    "1 redirect.ovh.net",
-  ]
-}
-
-resource "aws_route53_record" "mx_www_empatia" {
-  zone_id = aws_route53_zone.empatia.zone_id
-  name    = "www.${aws_route53_zone.empatia.name}"
-  type    = "MX"
-  ttl     = "300"
-  records = [
-    "1 redirect.ovh.net",
-  ]
-}
-
 resource "aws_route53_record" "ns_empatia" {
   zone_id = aws_route53_zone.empatia.zone_id
   name    = aws_route53_zone.empatia.name
   type    = "NS"
   ttl     = "172800"
   records = [
-    "ns-214.awsdns-26.com",
-    "ns-1083.awsdns-07.org",
-    "ns-1596.awsdns-07.co.uk",
-    "ns-854.awsdns-42.net",
+    "${aws_route53_zone.empatia.name_servers.0}.",
+    "${aws_route53_zone.empatia.name_servers.1}.",
+    "${aws_route53_zone.empatia.name_servers.2}.",
+    "${aws_route53_zone.empatia.name_servers.3}.",
   ]
 }
 
@@ -74,42 +33,10 @@ resource "aws_route53_record" "soa_empatia" {
   ]
 }
 
-resource "aws_route53_record" "cname_empatia" {
-  zone_id = aws_route53_zone.empatia.zone_id
-  name    = "_ac65bc401f2ef9831b5de3354b6cc298.${aws_route53_zone.empatia.name}"
-  type    = "CNAME"
-  ttl     = "300"
-  records = [
-    "_99b56888aa18364008e7b7ca51d0325c.ltfvzjuylp.acm-validations.aws",
-  ]
-}
-
-resource "aws_route53_record" "txt_empatia" {
-  zone_id = aws_route53_zone.empatia.zone_id
-  name    = aws_route53_zone.empatia.name
-  type    = "TXT"
-  ttl     = "300"
-  records = [
-    "\"1|www.${aws_route53_zone.empatia.name}\"",
-    "\"v=spf1 include:mx.ovh.com ~all\"",
-  ]
-}
-
-resource "aws_route53_record" "txt_www_empatia" {
-  zone_id = aws_route53_zone.empatia.zone_id
-  name    = "www.${aws_route53_zone.empatia.name}"
-  type    = "TXT"
-  ttl     = "300"
-  records = [
-    "\"3|welcome\"",
-    "\"l|pl\"",
-  ]
-}
-
 module empatia_ssl_certificate {
   source       = "./ssl_certificate"
 
-  domain       = aws_route53_zone.empatia.name
+  domain       = "bankempatii.pl"
   route53_zone = aws_route53_zone.empatia
 }
 
@@ -125,7 +52,7 @@ module empatia_cloudfront_distribution {
   source          = "./cloudfront_distribution"
 
   name            = "empatia"
-  domain          = aws_route53_zone.empatia.name
+  domain          = "bankempatii.pl"
   s3_bucket       = aws_s3_bucket.codeforpoznan_public
   route53_zone    = aws_route53_zone.empatia
   iam_user        = aws_iam_user.empatia


### PR DESCRIPTION
resolves #18 and #21.

Few notes:
I did not apply the changes. The PR is split into two commits, one for each PR.
I've removed most of the domains, as they seem unused. AFAIK most of these are created by default in OVH, but we don't really use them anywhere.
More info on these purpose-oriented domains can be found here: https://www.axigen.com/documentation/dns-based-service-discovery-p3277117

Also, I think that we can easily remove few more records by not caring about the `www.` prefix.
Still, I've included them as shown in Issue Description.

I'll also develop travis code for the corresponding repo.

<details>
  <summary>Click to expand the terraform plan</summary>

  ```
  ------------------------------------------------------------------------
  
  An execution plan has been generated and is shown below.
  Resource actions are indicated with the following symbols:
  + create
  
  Terraform will perform the following actions:
  
  # aws_iam_access_key.empatia will be created
    + resource "aws_iam_access_key" "empatia" {
        + encrypted_secret     = (known after apply)
            + id                   = (known after apply)
            + key_fingerprint      = (known after apply)
            + secret               = (sensitive value)
            + ses_smtp_password    = (sensitive value)
            + ses_smtp_password_v4 = (sensitive value)
            + status               = (known after apply)
            + user                 = "empatia"
    }
  
  # aws_iam_user.empatia will be created
  + resource "aws_iam_user" "empatia" {
      + arn           = (known after apply)
          + force_destroy = false
          + id            = (known after apply)
          + name          = "empatia"
          + path          = "/"
          + unique_id     = (known after apply)
  }
  
  # aws_route53_record.a_empatia will be created
  + resource "aws_route53_record" "a_empatia" {
      + allow_overwrite = (known after apply)
          + fqdn            = (known after apply)
          + id              = (known after apply)
          + name            = "bankempatii.pl"
          + type            = "A"
          + zone_id         = (known after apply)
  
          + alias {
              + evaluate_target_health = false
                  + name                   = "d6cxmr8432pje.cloudfront.net"
                  + zone_id                = "Z2FDTNDATAQYW2"
          }
  }
  
  # aws_route53_record.a_www_empatia will be created
  + resource "aws_route53_record" "a_www_empatia" {
      + allow_overwrite = (known after apply)
          + fqdn            = (known after apply)
          + id              = (known after apply)
          + name            = "www.bankempatii.pl"
          + records         = [
          + "176.31.162.42",
          ]
              + ttl             = 300
              + type            = "A"
              + zone_id         = (known after apply)
  }
  
  # aws_route53_record.cname_empatia will be created
  + resource "aws_route53_record" "cname_empatia" {
      + allow_overwrite = (known after apply)
          + fqdn            = (known after apply)
          + id              = (known after apply)
          + name            = "_ac65bc401f2ef9831b5de3354b6cc298.bankempatii.pl"
          + records         = [
          + "_99b56888aa18364008e7b7ca51d0325c.ltfvzjuylp.acm-validations.aws",
          ]
              + ttl             = 300
              + type            = "CNAME"
              + zone_id         = (known after apply)
  }
  
  # aws_route53_record.mx_empatia will be created
  + resource "aws_route53_record" "mx_empatia" {
      + allow_overwrite = (known after apply)
          + fqdn            = (known after apply)
          + id              = (known after apply)
          + name            = "bankempatii.pl"
          + records         = [
          + "1 redirect.ovh.net",
          ]
              + ttl             = 300
              + type            = "MX"
              + zone_id         = (known after apply)
  }
  
  # aws_route53_record.mx_www_empatia will be created
  + resource "aws_route53_record" "mx_www_empatia" {
      + allow_overwrite = (known after apply)
          + fqdn            = (known after apply)
          + id              = (known after apply)
          + name            = "www.bankempatii.pl"
          + records         = [
          + "1 redirect.ovh.net",
          ]
              + ttl             = 300
              + type            = "MX"
              + zone_id         = (known after apply)
  }
  
  # aws_route53_record.ns_empatia will be created
  + resource "aws_route53_record" "ns_empatia" {
      + allow_overwrite = (known after apply)
          + fqdn            = (known after apply)
          + id              = (known after apply)
          + name            = "bankempatii.pl"
          + records         = [
          + "ns-1083.awsdns-07.org",
          + "ns-1596.awsdns-07.co.uk",
          + "ns-214.awsdns-26.com",
          + "ns-854.awsdns-42.net",
          ]
              + ttl             = 172800
              + type            = "NS"
              + zone_id         = (known after apply)
  }
  
  # aws_route53_record.soa_empatia will be created
  + resource "aws_route53_record" "soa_empatia" {
      + allow_overwrite = (known after apply)
          + fqdn            = (known after apply)
          + id              = (known after apply)
          + name            = "bankempatii.pl"
          + records         = [
          + "ns-1596.awsdns-07.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400",
          ]
              + ttl             = 900
              + type            = "SOA"
              + zone_id         = (known after apply)
  }
  
  # aws_route53_record.txt_empatia will be created
  + resource "aws_route53_record" "txt_empatia" {
      + allow_overwrite = (known after apply)
          + fqdn            = (known after apply)
          + id              = (known after apply)
          + name            = "bankempatii.pl"
          + records         = [
          + "\"1|www.bankempatii.pl\"",
          + "\"v=spf1 include:mx.ovh.com ~all\"",
          ]
              + ttl             = 300
              + type            = "TXT"
              + zone_id         = (known after apply)
  }
  
  # aws_route53_record.txt_www_empatia will be created
  + resource "aws_route53_record" "txt_www_empatia" {
      + allow_overwrite = (known after apply)
          + fqdn            = (known after apply)
          + id              = (known after apply)
          + name            = "www.bankempatii.pl"
          + records         = [
          + "\"3|welcome\"",
          + "\"l|pl\"",
          ]
              + ttl             = 300
              + type            = "TXT"
              + zone_id         = (known after apply)
  }
  
  # aws_route53_zone.empatia will be created
  + resource "aws_route53_zone" "empatia" {
      + comment       = "Managed by Terraform"
          + force_destroy = false
          + id            = (known after apply)
          + name          = "bankempatii.pl"
          + name_servers  = (known after apply)
          + vpc_id        = (known after apply)
          + vpc_region    = (known after apply)
          + zone_id       = (known after apply)
  }
  
  # module.empatia_cloudfront_distribution.aws_cloudfront_distribution.distribution will be created
  + resource "aws_cloudfront_distribution" "distribution" {
      + active_trusted_signers         = (known after apply)
          + aliases                        = [
          + "bankempatii.pl",
          ]
              + arn                            = (known after apply)
              + caller_reference               = (known after apply)
              + default_root_object            = "index.html"
              + domain_name                    = (known after apply)
              + enabled                        = true
              + etag                           = (known after apply)
              + hosted_zone_id                 = (known after apply)
              + http_version                   = "http2"
              + id                             = (known after apply)
              + in_progress_validation_batches = (known after apply)
              + is_ipv6_enabled                = true
              + last_modified_time             = (known after apply)
              + price_class                    = "PriceClass_All"
              + retain_on_delete               = false
              + status                         = (known after apply)
              + wait_for_deployment            = true
  
              + default_cache_behavior {
                  + allowed_methods        = [
                      + "GET",
                  + "HEAD",
                  ]
                      + cached_methods         = [
                      + "GET",
                  + "HEAD",
                      ]
                          + compress               = false
                          + default_ttl            = 3600
                          + max_ttl                = 86400
                          + min_ttl                = 0
                          + target_origin_id       = "static_assets"
                          + viewer_protocol_policy = "redirect-to-https"
  
                          + forwarded_values {
                              + query_string = false
  
                                  + cookies {
                                      + forward = "none"
                                  }
                          }
              }
  
      + origin {
          + domain_name = "codeforpoznan-public.s3.amazonaws.com"
              + origin_id   = "static_assets"
              + origin_path = "/empatia"
      }
  
      + restrictions {
          + geo_restriction {
              + restriction_type = "none"
          }
      }
  
      + viewer_certificate {
          + acm_certificate_arn      = (known after apply)
              + minimum_protocol_version = "TLSv1"
              + ssl_support_method       = "sni-only"
      }
  }
  
  # module.empatia_cloudfront_distribution.aws_iam_policy.policy will be created
  + resource "aws_iam_policy" "policy" {
      + arn    = (known after apply)
          + id     = (known after apply)
          + name   = "empatia_cloudfront_distribution"
          + path   = "/"
          + policy = (known after apply)
  }
  
  # module.empatia_cloudfront_distribution.aws_iam_user_policy_attachment.user_policy_attachment will be created
  + resource "aws_iam_user_policy_attachment" "user_policy_attachment" {
      + id         = (known after apply)
          + policy_arn = (known after apply)
          + user       = "empatia"
  }
  
  # module.empatia_cloudfront_distribution.aws_route53_record.main_record will be created
  + resource "aws_route53_record" "main_record" {
      + allow_overwrite = (known after apply)
          + fqdn            = (known after apply)
          + id              = (known after apply)
          + name            = "bankempatii.pl"
          + type            = "A"
          + zone_id         = (known after apply)
  
          + alias {
              + evaluate_target_health = false
                  + name                   = (known after apply)
                  + zone_id                = (known after apply)
          }
  }
  
  # module.empatia_frontend_assets.aws_iam_policy.policy will be created
  + resource "aws_iam_policy" "policy" {
      + arn    = (known after apply)
          + id     = (known after apply)
          + name   = "empatia_frontend_assets"
          + path   = "/"
          + policy = jsonencode(
                  {
                  + Statement = [
                  + {
                  + Action   = [
                  + "s3:DeleteObject",
                  + "s3:PutObject",
                  ]
                  + Effect   = "Allow"
                  + Resource = [
                  + "arn:aws:s3:::codeforpoznan-public/empatia/*",
                  ]
                  + Sid      = "EmpatiaS3"
                  },
                  ]
                  + Version   = "2012-10-17"
                  }
                  )
  }
  
  # module.empatia_frontend_assets.aws_iam_user_policy_attachment.user_policy_attachment will be created
  + resource "aws_iam_user_policy_attachment" "user_policy_attachment" {
      + id         = (known after apply)
          + policy_arn = (known after apply)
          + user       = "empatia"
  }
  
  # module.empatia_frontend_assets.aws_s3_bucket_object.bucket_object will be created
  + resource "aws_s3_bucket_object" "bucket_object" {
      + acl                    = "private"
          + bucket                 = "codeforpoznan-public"
          + content_type           = (known after apply)
          + etag                   = (known after apply)
          + force_destroy          = false
          + id                     = (known after apply)
          + key                    = "empatia/"
          + server_side_encryption = (known after apply)
          + storage_class          = (known after apply)
          + version_id             = (known after apply)
  }
  
  # module.empatia_ssl_certificate.aws_acm_certificate.certificate will be created
  + resource "aws_acm_certificate" "certificate" {
      + arn                       = (known after apply)
          + domain_name               = "bankempatii.pl"
          + domain_validation_options = (known after apply)
          + id                        = (known after apply)
          + subject_alternative_names = (known after apply)
          + validation_emails         = (known after apply)
          + validation_method         = "DNS"
  }
  
  # module.empatia_ssl_certificate.aws_acm_certificate_validation.certificate_validation will be created
  + resource "aws_acm_certificate_validation" "certificate_validation" {
      + certificate_arn         = (known after apply)
          + id                      = (known after apply)
          + validation_record_fqdns = (known after apply)
  }
  
  # module.empatia_ssl_certificate.aws_route53_record.certificate_validation_record will be created
  + resource "aws_route53_record" "certificate_validation_record" {
      + allow_overwrite = (known after apply)
          + fqdn            = (known after apply)
          + id              = (known after apply)
          + name            = (known after apply)
          + records         = (known after apply)
          + ttl             = 60
          + type            = (known after apply)
          + zone_id         = (known after apply)
  }
  
  Plan: 22 to add, 0 to change, 0 to destroy.
  
  ------------------------------------------------------------------------
  ```
</details>