### PR TITLE
[58] Rewrite all IAM policies as documents

### DIFF
--- a/cloudfront_distribution/main.tf
+++ b/cloudfront_distribution/main.tf
@@ -138,20 +138,20 @@ resource "aws_route53_record" "main_record" {
   ]
 }
 
-resource "aws_iam_policy" "policy" {
-  name = "${var.name}_cloudfront_distribution"
+data "aws_iam_policy_document" "policy" {
+  version = "2012-10-17"
 
-  policy = <<POLICY
-{
-  "Version":"2012-10-17",
-  "Statement":[{
-    "Sid":"${replace(title(replace(var.name, "/[\\._]/", " ")), " ", "")}CloudFront",
-    "Effect":"Allow",
-    "Action":["cloudfront:CreateInvalidation"],
-    "Resource":["${aws_cloudfront_distribution.distribution.arn}"]
-  }]
+  statement {
+    sid       = "${replace(title(replace(var.name, "/[\\._]/", " ")), " ", "")}CloudFront"
+    effect    = "Allow"
+    actions   = ["cloudfront:CreateInvalidation"]
+    resources = [aws_cloudfront_distribution.distribution.arn]
+  }
 }
-  POLICY
+
+resource "aws_iam_policy" "policy" {
+  name   = "${var.name}_cloudfront_distribution"
+  policy = data.aws_iam_policy_document.policy.json
 
   depends_on = [
     aws_cloudfront_distribution.distribution,

--- a/codeforpoznan_pl_v2.tf
+++ b/codeforpoznan_pl_v2.tf
@@ -28,20 +28,25 @@ module codeforpoznan_pl_mailing_identity {
   route53_zone = aws_route53_zone.codeforpoznan_pl
 }
 
-resource "aws_iam_policy" "codeforpoznan_pl_ses_policy" {
-  name = "codeforpoznan_pl_v2_lambda_execution_policy"
+data "aws_iam_policy_document" "codeforpoznan_pl_ses_policy_document" {
+  version = "2012-10-17"
 
-  policy = <<POLICY
-{
-  "Version":"2012-10-17",
-  "Statement":[{
-    "Sid":"CodeforpoznanPlV2SES",
-    "Effect":"Allow",
-    "Action":["ses:SendEmail", "ses:SendRawEmail"],
-    "Resource":["${module.codeforpoznan_pl_mailing_identity.domain_identity.arn}"]
-  }]
+  statement {
+    sid    = "CodeforpoznanPlV2SES"
+    effect = "Allow"
+    actions = [
+      "ses:SendEmail",
+      "ses:SendRawEmail",
+    ]
+    resources = [
+      module.codeforpoznan_pl_mailing_identity.domain_identity.arn
+    ]
+  }
 }
-  POLICY
+
+resource "aws_iam_policy" "codeforpoznan_pl_ses_policy" {
+  name   = "codeforpoznan_pl_v2_lambda_execution_policy"
+  policy = data.aws_iam_policy_document.codeforpoznan_pl_ses_policy_document.json
 
   depends_on = [
     module.codeforpoznan_pl_mailing_identity.domain_identity,

--- a/codeforpoznan_pl_v2.tf
+++ b/codeforpoznan_pl_v2.tf
@@ -28,7 +28,7 @@ module codeforpoznan_pl_mailing_identity {
   route53_zone = aws_route53_zone.codeforpoznan_pl
 }
 
-data "aws_iam_policy_document" "codeforpoznan_pl_ses_policy_document" {
+data "aws_iam_policy_document" "codeforpoznan_pl_ses_policy" {
   version = "2012-10-17"
 
   statement {
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "codeforpoznan_pl_ses_policy_document" {
 
 resource "aws_iam_policy" "codeforpoznan_pl_ses_policy" {
   name   = "codeforpoznan_pl_v2_lambda_execution_policy"
-  policy = data.aws_iam_policy_document.codeforpoznan_pl_ses_policy_document.json
+  policy = data.aws_iam_policy_document.codeforpoznan_pl_ses_policy.json
 
   depends_on = [
     module.codeforpoznan_pl_mailing_identity.domain_identity,

--- a/frontend_assets/main.tf
+++ b/frontend_assets/main.tf
@@ -14,20 +14,20 @@ resource "aws_s3_bucket_object" "bucket_object" {
   ]
 }
 
-resource "aws_iam_policy" "policy" {
-  name = "${var.name}_frontend_assets"
+data "aws_iam_policy_document" "policy" {
+  version = "2012-10-17"
 
-  policy = <<POLICY
-{
-  "Version":"2012-10-17",
-  "Statement":[{
-    "Sid":"${replace(title(replace(var.name, "/[\\._]/", " ")), " ", "")}S3",
-    "Effect":"Allow",
-    "Action":["s3:DeleteObject", "s3:PutObject"],
-    "Resource":["${var.s3_bucket.arn}/${aws_s3_bucket_object.bucket_object.key}*"]
-  }]
+  statement {
+    sid       = "${replace(title(replace(var.name, "/[\\._]/", " ")), " ", "")}S3"
+    effect    = "Allow"
+    actions   = ["s3:DeleteObject", "s3:PutObject"]
+    resources = ["${var.s3_bucket.arn}/${aws_s3_bucket_object.bucket_object.key}*"]
+  }
 }
-  POLICY
+
+resource "aws_iam_policy" "policy" {
+  name   = "${var.name}_frontend_assets"
+  policy = data.aws_iam_policy_document.policy.json
 
   depends_on = [
     aws_s3_bucket_object.bucket_object,

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -43,6 +43,7 @@ data "aws_iam_policy_document" "role" {
   version = "2012-10-17"
 
   statement {
+    sid = ""
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "role" {
   version = "2012-10-17"
 
   statement {
-    sid = ""
+    sid     = ""
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
     principals {

--- a/lambda/main.tf
+++ b/lambda/main.tf
@@ -39,25 +39,22 @@ variable envvars {
   default = {}
 }
 
+data "aws_iam_policy_document" "role" {
+  version = "2012-10-17"
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
 resource "aws_iam_role" "role" {
   name               = var.name
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": [
-            "lambda.amazonaws.com"
-        ]
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-  POLICY
+  assume_role_policy = data.aws_iam_policy_document.role.json
 }
 
 resource "aws_iam_role_policy_attachment" "basic_role_policy_attachment" {
@@ -127,25 +124,27 @@ resource "aws_lambda_function" "function" {
   ]
 }
 
-resource "aws_iam_policy" "policy" {
-  name = var.name
+data "aws_iam_policy_document" "policy" {
+  version = "2012-10-17"
 
-  policy = <<POLICY
-{
-  "Version":"2012-10-17",
-  "Statement":[{
-    "Sid":"${replace(title(replace(var.name, "/[\\._]/", " ")), " ", "")}S3",
-    "Effect":"Allow",
-    "Action":["s3:GetObject", "s3:PutObject"],
-    "Resource":["${var.s3_bucket.arn}/${aws_s3_bucket_object.bucket_object.key}"]
-  }, {
-    "Sid":"${replace(title(replace(var.name, "/[\\._]/", " ")), " ", "")}Lambda",
-    "Effect":"Allow",
-    "Action":["lambda:UpdateFunctionCode"%{if var.user_can_invoke}, "lambda:InvokeFunction"%{endif}],
-    "Resource":["${aws_lambda_function.function.arn}"]
-  }]
+  statement {
+    sid       = "${replace(title(replace(var.name, "/[\\._]/", " ")), " ", "")}S3"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject"]
+    resources = ["${var.s3_bucket.arn}/${aws_s3_bucket_object.bucket_object.key}"]
+  }
+
+  statement {
+    sid       = "${replace(title(replace(var.name, "/[\\._]/", " ")), " ", "")}Lambda"
+    effect    = "Allow"
+    actions   = var.user_can_invoke ? ["lambda:UpdateFunctionCode", "lambda:InvokeFunction"] : ["lambda:UpdateFunctionCode"]
+    resources = [aws_lambda_function.function.arn]
+  }
 }
-  POLICY
+
+resource "aws_iam_policy" "policy" {
+  name   = var.name
+  policy = data.aws_iam_policy_document.policy.json
 
   depends_on = [
     aws_s3_bucket_object.bucket_object,

--- a/main.tf
+++ b/main.tf
@@ -27,8 +27,8 @@ data "aws_iam_policy_document" "codeforpoznan_public_policy" {
   }
 
   statement {
-    sid       = "PublicGetObject"
-    effect    = "Allow"
+    sid    = "PublicGetObject"
+    effect = "Allow"
     principals {
       identifiers = ["*"]
       type        = "*"

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ provider "aws" {
   profile = "codeforpoznan"
 }
 
-data "aws_iam_policy_document" "codeforpoznan_public_policy_document" {
+data "aws_iam_policy_document" "codeforpoznan_public_policy" {
   version = "2012-10-17"
 
   statement {
@@ -29,6 +29,10 @@ data "aws_iam_policy_document" "codeforpoznan_public_policy_document" {
   statement {
     sid       = "PublicGetObject"
     effect    = "Allow"
+    principals {
+      identifiers = ["*"]
+      type        = "*"
+    }
     actions   = ["s3:GetObject"]
     resources = ["arn:aws:s3:::codeforpoznan-public/*"]
   }
@@ -43,7 +47,7 @@ resource "aws_s3_bucket" "codeforpoznan_public" {
     allowed_origins = ["*"]
   }
 
-  policy = data.aws_iam_policy_document.codeforpoznan_public_policy_document.json
+  policy = data.aws_iam_policy_document.codeforpoznan_public_policy.json
 }
 
 // shared private bucket for storing zipped projects and lambdas code

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,28 @@ provider "aws" {
   profile = "codeforpoznan"
 }
 
+data "aws_iam_policy_document" "codeforpoznan_public_policy_document" {
+  version = "2012-10-17"
+
+  statement {
+    sid    = "PublicListBucket"
+    effect = "Allow"
+    principals {
+      identifiers = ["*"]
+      type        = "*"
+    }
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::codeforpoznan-public"]
+  }
+
+  statement {
+    sid       = "PublicGetObject"
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::codeforpoznan-public/*"]
+  }
+}
+
 // shared public bucket (we will push here all static assets in separate directories)
 resource "aws_s3_bucket" "codeforpoznan_public" {
   bucket = "codeforpoznan-public"
@@ -21,24 +43,7 @@ resource "aws_s3_bucket" "codeforpoznan_public" {
     allowed_origins = ["*"]
   }
 
-  policy = <<POLICY
-{
-  "Version":"2012-10-17",
-  "Statement":[{
-    "Sid":"PublicListBucket",
-    "Effect":"Allow",
-    "Principal": "*",
-    "Action":["s3:ListBucket"],
-    "Resource":["arn:aws:s3:::codeforpoznan-public"]
-  }, {
-    "Sid":"PublicGetObject",
-    "Effect":"Allow",
-    "Principal": "*",
-    "Action":["s3:GetObject"],
-    "Resource":["arn:aws:s3:::codeforpoznan-public/*"]
-  }]
-}
-    POLICY
+  policy = data.aws_iam_policy_document.codeforpoznan_public_policy_document.json
 }
 
 // shared private bucket for storing zipped projects and lambdas code


### PR DESCRIPTION
Closes #58 
This change does not require apply. It is technically a no-op from terraform state's point of view.