### PR TITLE
[66] Move route53 zones to new module

### DIFF
--- a/codeforpoznan_pl.tf
+++ b/codeforpoznan_pl.tf
@@ -1,33 +1,12 @@
-resource "aws_route53_zone" "codeforpoznan_pl" {
-  name = "codeforpoznan.pl"
-}
+module codeforpoznan_pl_route53_zone {
+  source = "./route53_zone"
 
-resource "aws_route53_record" "ns_codeforpoznan_pl" {
-  zone_id = aws_route53_zone.codeforpoznan_pl.zone_id
-  name    = aws_route53_zone.codeforpoznan_pl.name
-  type    = "NS"
-  ttl     = "172800"
-  records = [
-    "${aws_route53_zone.codeforpoznan_pl.name_servers.0}.",
-    "${aws_route53_zone.codeforpoznan_pl.name_servers.1}.",
-    "${aws_route53_zone.codeforpoznan_pl.name_servers.2}.",
-    "${aws_route53_zone.codeforpoznan_pl.name_servers.3}.",
-  ]
-}
-
-resource "aws_route53_record" "soa_codeforpoznan_pl" {
-  zone_id = aws_route53_zone.codeforpoznan_pl.zone_id
-  name    = aws_route53_zone.codeforpoznan_pl.name
-  type    = "SOA"
-  ttl     = "900"
-  records = [
-    "ns-1211.awsdns-23.org. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400",
-  ]
+  domain = "codeforpoznan.pl"
 }
 
 resource "aws_route53_record" "mx_codeforpoznan_pl" {
-  zone_id = aws_route53_zone.codeforpoznan_pl.zone_id
-  name    = aws_route53_zone.codeforpoznan_pl.name
+  zone_id = module.codeforpoznan_pl_route53_zone.zone.zone_id
+  name    = module.codeforpoznan_pl_route53_zone.zone.name
   type    = "MX"
   ttl     = "300"
   records = [
@@ -40,8 +19,8 @@ resource "aws_route53_record" "mx_codeforpoznan_pl" {
 }
 
 resource "aws_route53_record" "txt_codeforpoznan_pl" {
-  zone_id = aws_route53_zone.codeforpoznan_pl.zone_id
-  name    = aws_route53_zone.codeforpoznan_pl.name
+  zone_id = module.codeforpoznan_pl_route53_zone.zone.zone_id
+  name    = module.codeforpoznan_pl_route53_zone.zone.name
   type    = "TXT"
   ttl     = "300"
   records = [
@@ -56,7 +35,7 @@ resource "aws_route53_record" "txt_codeforpoznan_pl" {
 
 # https://support.google.com/a/answer/174126
 resource "aws_route53_record" "dkim_google" {
-  zone_id = aws_route53_zone.codeforpoznan_pl.zone_id
+  zone_id = module.codeforpoznan_pl_route53_zone.zone.zone_id
   name    = "google._domainkey.codeforpoznan.pl"
   type    = "TXT"
   ttl     = "300"
@@ -67,7 +46,7 @@ resource "aws_route53_record" "dkim_google" {
 
 # https://support.google.com/a/answer/2466563
 resource "aws_route53_record" "dmarc" {
-  zone_id = aws_route53_zone.codeforpoznan_pl.zone_id
+  zone_id = module.codeforpoznan_pl_route53_zone.zone.zone_id
   name    = "_dmarc.codeforpoznan.pl"
   type    = "TXT"
   ttl     = "300"
@@ -76,13 +55,3 @@ resource "aws_route53_record" "dmarc" {
   ]
 }
 
-# That's not working properly right now, will be fixed in CodeForPoznan/Infrastructure#51
-resource "aws_route53_record" "www_codeforpoznan_pl" {
-  zone_id = aws_route53_zone.codeforpoznan_pl.zone_id
-  name    = "www.codeforpoznan.pl."
-  type    = "CNAME"
-  ttl     = "300"
-  records = [
-    "codeforpoznan.pl.",
-  ]
-}

--- a/codeforpoznan_pl_v2.tf
+++ b/codeforpoznan_pl_v2.tf
@@ -10,7 +10,7 @@ module codeforpoznan_pl_v2_ssl_certificate {
   source = "./ssl_certificate"
 
   domain       = "codeforpoznan.pl"
-  route53_zone = aws_route53_zone.codeforpoznan_pl
+  route53_zone = module.codeforpoznan_pl_route53_zone.zone
 }
 
 module codeforpoznan_pl_v2_frontend_assets {
@@ -25,7 +25,7 @@ module codeforpoznan_pl_mailing_identity {
   source = "./mailing_identity"
 
   domain       = "codeforpoznan.pl"
-  route53_zone = aws_route53_zone.codeforpoznan_pl
+  route53_zone = module.codeforpoznan_pl_route53_zone.zone
 }
 
 resource "aws_iam_policy" "codeforpoznan_pl_ses_policy" {
@@ -65,7 +65,7 @@ module codeforpoznan_pl_v2_cloudfront_distribution {
   name            = "codeforpoznan.pl_v2"
   domain          = "codeforpoznan.pl"
   s3_bucket       = aws_s3_bucket.codeforpoznan_public
-  route53_zone    = aws_route53_zone.codeforpoznan_pl
+  route53_zone    = module.codeforpoznan_pl_route53_zone.zone
   iam_user        = aws_iam_user.codeforpoznan_pl_v2
   acm_certificate = module.codeforpoznan_pl_v2_ssl_certificate.certificate
 

--- a/codeforpoznan_pl_v3.tf
+++ b/codeforpoznan_pl_v3.tf
@@ -10,7 +10,7 @@ module codeforpoznan_pl_v3_ssl_certificate {
   source = "./ssl_certificate"
 
   domain       = "dev.codeforpoznan.pl"
-  route53_zone = aws_route53_zone.codeforpoznan_pl
+  route53_zone = module.codeforpoznan_pl_route53_zone.zone
 }
 
 module codeforpoznan_pl_v3_frontend_assets {
@@ -27,7 +27,7 @@ module codeforpoznan_pl_v3_cloudfront_distribution {
   name            = "codeforpoznan.pl_v3"
   domain          = "dev.codeforpoznan.pl"
   s3_bucket       = aws_s3_bucket.codeforpoznan_public
-  route53_zone    = aws_route53_zone.codeforpoznan_pl
+  route53_zone    = module.codeforpoznan_pl_route53_zone.zone
   iam_user        = aws_iam_user.codeforpoznan_pl_v3
   acm_certificate = module.codeforpoznan_pl_v3_ssl_certificate.certificate
 

--- a/dev_alinka_website.tf
+++ b/dev_alinka_website.tf
@@ -10,7 +10,7 @@ module dev_alinka_website_ssl_certificate {
   source = "./ssl_certificate"
 
   domain       = "dev.alinka.io"
-  route53_zone = aws_route53_zone.alinka_website
+  route53_zone = module.alinka_website_route53_zone.zone
 }
 
 module dev_alinka_website_frontend_assets {
@@ -27,7 +27,7 @@ module dev_alinka_website_cloudfront_distribution {
   name            = "dev_alinka_website"
   domain          = "dev.alinka.io"
   s3_bucket       = aws_s3_bucket.codeforpoznan_public
-  route53_zone    = aws_route53_zone.alinka_website
+  route53_zone    = module.alinka_website_route53_zone.zone
   iam_user        = aws_iam_user.dev_alinka_website
   acm_certificate = module.dev_alinka_website_ssl_certificate.certificate
 

--- a/dev_pah_fm.tf
+++ b/dev_pah_fm.tf
@@ -52,7 +52,7 @@ module dev_pah_fm_ssl_certificate {
   source = "./ssl_certificate"
 
   domain       = "dev.pahfm.codeforpoznan.pl"
-  route53_zone = aws_route53_zone.codeforpoznan_pl
+  route53_zone = module.codeforpoznan_pl_route53_zone.zone
 }
 
 module dev_pah_fm_frontend_assets {
@@ -99,7 +99,7 @@ module dev_pah_fm_cloudfront_distribution {
   name            = "dev_pah_fm"
   domain          = "dev.pahfm.codeforpoznan.pl"
   s3_bucket       = aws_s3_bucket.codeforpoznan_public
-  route53_zone    = aws_route53_zone.codeforpoznan_pl
+  route53_zone    = module.codeforpoznan_pl_route53_zone.zone
   iam_user        = aws_iam_user.dev_pah_fm
   acm_certificate = module.dev_pah_fm_ssl_certificate.certificate
 

--- a/empatia.tf
+++ b/empatia.tf
@@ -23,6 +23,7 @@ resource "aws_route53_record" "ns_empatia" {
   ]
 }
 
+# todo: move it to route53_zone record
 resource "aws_route53_record" "soa_empatia" {
   zone_id = aws_route53_zone.empatia.zone_id
   name    = aws_route53_zone.empatia.name

--- a/pah_fm.tf
+++ b/pah_fm.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "pah_fm" {
-  zone_id = aws_route53_zone.codeforpoznan_pl.zone_id
+  zone_id = module.codeforpoznan_pl_route53_zone.zone.zone_id
   name    = "pahfm.codeforpoznan.pl."
   type    = "A"
   ttl     = "300"
@@ -9,7 +9,7 @@ resource "aws_route53_record" "pah_fm" {
 }
 
 resource "aws_route53_record" "wildcard_pah_fm" {
-  zone_id = aws_route53_zone.codeforpoznan_pl.zone_id
+  zone_id = module.codeforpoznan_pl_route53_zone.zone.zone_id
   name    = "*.pahfm.codeforpoznan.pl."
   type    = "A"
   ttl     = "300"

--- a/presentations.tf
+++ b/presentations.tf
@@ -10,7 +10,7 @@ module presentations_ssl_certificate {
   source = "./ssl_certificate"
 
   domain       = "slides.codeforpoznan.pl"
-  route53_zone = aws_route53_zone.codeforpoznan_pl
+  route53_zone = module.codeforpoznan_pl_route53_zone.zone
 }
 
 module presentations_frontend_assets {
@@ -27,7 +27,7 @@ module presentations_cloudfront_distribution {
   name            = "Presentations"
   domain          = "slides.codeforpoznan.pl"
   s3_bucket       = aws_s3_bucket.codeforpoznan_public
-  route53_zone    = aws_route53_zone.codeforpoznan_pl
+  route53_zone    = module.codeforpoznan_pl_route53_zone.zone
   iam_user        = aws_iam_user.presentations
   acm_certificate = module.presentations_ssl_certificate.certificate
 

--- a/route53_zone/main.tf
+++ b/route53_zone/main.tf
@@ -1,0 +1,34 @@
+variable "domain" {
+  type = string
+}
+
+resource "aws_route53_zone" "zone" {
+  name = var.domain
+}
+
+resource "aws_route53_record" "ns" {
+  zone_id = aws_route53_zone.zone.zone_id
+  name    = aws_route53_zone.zone.name
+  type    = "NS"
+  ttl     = "172800"
+  records = [
+    "${aws_route53_zone.zone.name_servers.0}.",
+    "${aws_route53_zone.zone.name_servers.1}.",
+    "${aws_route53_zone.zone.name_servers.2}.",
+    "${aws_route53_zone.zone.name_servers.3}.",
+  ]
+}
+
+resource "aws_route53_record" "soa" {
+  zone_id = aws_route53_zone.zone.zone_id
+  name    = aws_route53_zone.zone.name
+  type    = "SOA"
+  ttl     = "900"
+  records = [
+    "ns-1143.awsdns-14.org. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400",
+  ]
+}
+
+output "zone" {
+  value = aws_route53_zone.zone
+}


### PR DESCRIPTION
_I have not applied that code, I've not even `tf plan`'ed it either. Resources were not moved._

This is a draft for moving the zone into separate module. It still has few rough edges (mainly the external `route53_record`s which I can't hide in module that easily without using `for_each` which doesn't work in `0.12`), so I'm leaving it off like that.

