### PR TITLE
Bump postgres version to 12.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .terraform/
+.envrc

--- a/db.tf
+++ b/db.tf
@@ -16,7 +16,7 @@ resource "aws_db_instance" "db" {
   identifier = "main-postgres"
 
   engine         = "postgres"
-  engine_version = "9.5"
+  engine_version = "12.5"
 
   instance_class    = "db.t2.micro"
   allocated_storage = 8


### PR DESCRIPTION
Regarding https://aws.amazon.com/blogs/database/upgrading-from-amazon-rds-for-postgresql-version-9-5/
No action needed, upgrade was done seamlessly by AWS during the maintenance window.