### PR TITLE
Zmiana zawiera 3 uaktualnienia:

### DIFF
--- a/admin/main.tf
+++ b/admin/main.tf
@@ -9,10 +9,6 @@ resource "aws_iam_user" "user" {
   name = var.name
 }
 
-resource "aws_iam_access_key" "access_key" {
-  user = aws_iam_user.user.name
-}
-
 resource "aws_iam_user_policy_attachment" "policy_attachment" {
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
   user       = aws_iam_user.user.name

--- a/database/main.tf
+++ b/database/main.tf
@@ -4,10 +4,6 @@ variable "name" {
 
 variable "db_instance" {}
 
-
-// https://github.com/hashicorp/terraform/issues/8367
-// before running terraform create a ssh tunel
-// ssh ubuntu@bastion.codeforpoznan.pl -L 15432:main-postgres.ct6cadodkpjm.eu-west-1.rds.amazonaws.com:5432
 provider "postgresql" {
   host            = "127.0.0.1" // var.db_instance.address
   port            = "15432"     // var.db_instance.port

--- a/db.tf
+++ b/db.tf
@@ -16,7 +16,7 @@ resource "aws_db_instance" "db" {
   identifier = "main-postgres"
 
   engine         = "postgres"
-  engine_version = "13.18"
+  engine_version = "13.20"
 
   instance_class    = "db.t3.micro"
   allocated_storage = 8

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "ssh_tunnel" {
+  value       = "ubuntu@${aws_route53_record.bastion.name} -L 15432:${aws_db_instance.db.address}:${aws_db_instance.db.port}"
+  description = <<-DESCRIPTION
+    https://github.com/hashicorp/terraform/issues/8367
+    before running terraform create a ssh tunel
+  DESCRIPTION
+}


### PR DESCRIPTION
* instancja AWS RDS otrzymała PostgreSQL minor upgrade z 13.18 do 13.20
* komenda ssh zamiast być zahadrkodowana, jest interpolowana jako terraform output
* usuwam ze stanu terraformowego access keys administratorów (sam musiałem swój klucz przerotować
  - zrobiłem to ręcznie, a jednocześnie nie ma powodu by jeden administrator miał dostęp do credentiali innych administratorów)